### PR TITLE
Fix luamin binary in older Node versions.

### DIFF
--- a/bin/luamin
+++ b/bin/luamin
@@ -91,13 +91,14 @@
 	} else {
 		// handle pipe
 		data = '';
-		stdin.on('readable', function() {
-			data += this.read();
+		stdin.on('data', function(chunk) {
+			data += chunk;
 		});
 		stdin.on('end', function() {
 			snippets.unshift(data.trim());
 			main();
 		});
+		stdin.resume();
 	}
 
 }());


### PR DESCRIPTION
Readable was not introduced before Node v0.10 http://nodejs.org/api/stream.html#stream_compatibility

I haven't actually worked with streams so I have no idea if this is how it's supposed to be done, however it seems to work with v0.8.1 upwards.
