### PR TITLE
Preserve TableKeyString identifiers

### DIFF
--- a/luamin.js
+++ b/luamin.js
@@ -344,8 +344,8 @@
 				} else if (field.type == 'TableValue') {
 					result += formatExpression(field.value);
 				} else { // at this point, `field.type == 'TableKeyString'`
-					result += formatExpression(field.key) + '=' +
-						formatExpression(field.value);
+					result += formatExpression(field.key, { preserveIdentifiers: true }) +
+						'=' + formatExpression(field.value);
 				}
 				if (needsComma) {
 					result += ',';

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2006,6 +2006,15 @@
 			}
 		],
 
+		// TableKey
+		'TableKey': [
+			{
+				'description': 'TableKeyString',
+				'original': 'function f(x) end function g(y) local h = { x = y } end',
+				'minified': 'function f(a)end;function g(b)local c={x=b}end',
+			}
+		],
+
 		// Miscellaneous
 		'Miscellaneous': [
 			{


### PR DESCRIPTION
Closes #17

Guess luamin should really keep track of nested scopes so `TableKeyString`s can be minified, if you prefer going for that without this "temporary" fix feel free to close this.
