### PR TITLE
Fixes #12 where man page would not be present after package install using npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"homepage": "http://mths.be/luamin",
 	"main": "luamin.js",
 	"bin": "bin/luamin",
-	"man": "man/luamin.1",
 	"keywords": [
 		"lua",
 		"minify",


### PR DESCRIPTION
Resolves issues presented https://github.com/npm/npm/issues/3405 and https://github.com/npm/npm/issues/109.

The secret sauce was found with a little trial and error after reading this article [Unix and Node: Manual Pages - Installing Manual Pages](http://dailyjs.com/2012/02/16/unix-node-community/#installing_manual_pages). It wasn't very clear at first, but the key was to point to the folder where the roff file lives and not the path to the roff file:

```
"directories": {
  "man": "<folder_to_manpage>"
}
```

So the following are incorrect:

```
"bin": "bin/luamin",
"man": "man/luamin.1",
...
```

```
"bin": "bin/luamin",
"man": "man/luamin.1",
"directories": {
  "man": "man/luamin.1"
},
...
```

```
"bin": "bin/luamin",
"directories": {
  "man": "man/luamin.1"
},
...
```

This is the correct way:
- No `man` key at the root level
- A `directories` entry with a `man` key that has a value which points to the folder where the roff file lives

```
"bin": "bin/luamin",
"directories": {
  "man": "man"
}
```
