### PR TITLE
Fix shortening 'self'. Fixes #21

### DIFF
--- a/luamin.js
+++ b/luamin.js
@@ -123,6 +123,11 @@
 	var identifierMap;
 	var identifiersInUse;
 	var generateIdentifier = function(originalName) {
+		// This is required to preserve self in methods
+		if (originalName == 'self') {
+			return originalName;
+		}
+
 		if (hasOwnProperty.call(identifierMap, originalName)) {
 			return identifierMap[originalName];
 		}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2003,6 +2003,11 @@
 				'description': 'Identifier in MemberExpression',
 				'original': 'local x = y() print(x:someProperty())',
 				'minified': 'local a=y()print(a:someProperty())'
+			},
+			{
+				'description': 'Variable shortening should not shorten "self" in a function',
+				'original': 'local t = {num = 2} function t:func() return self.num end',
+				'minified': 'local a={num=2}function a:func()return self.num end'
 			}
 		],
 


### PR DESCRIPTION
This is kind of awkward because it does not shorten 'self' no matter the context, but the alternative would have been to add "options" param to all statements etc, which I think is an overkill.