### PR TITLE
Fix parens being removed from string literal calls

### DIFF
--- a/luamin.js
+++ b/luamin.js
@@ -211,7 +211,8 @@
 			type == 'BinaryExpression' ||
 			type == 'FunctionDeclaration' ||
 			type == 'TableConstructorExpression' ||
-			type == 'LogicalExpression'
+			type == 'LogicalExpression' ||
+			type == 'StringLiteral'
 		);
 		if (needsParens) {
 			result += '(';

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -496,6 +496,11 @@
 				'description': 'LogicalExpression in parenthesis + MemberExpression + CallExpression',
 				'original': '(x or y):f()',
 				'minified': '(x or y):f()'
+			},
+			{
+				'description': 'StringLiteral in parenthesis + MemberExpression + CallExpression',
+				'original': '("abc"):f()',
+				'minified': '("abc"):f()'
 			}
 		],
 
@@ -718,7 +723,7 @@
 			{
 				'description': 'CallStatement',
 				'original': '("foo")()',
-				'minified': '"foo"()'
+				'minified': '("foo")()'
 			},
 			{
 				'description': 'CallStatement',


### PR DESCRIPTION
Fixes #42.

One of the 'CallExpression' tests returned invalid Lua, so I fixed that as well. Here's a snippet I used to verify that strings can have __call that can be called if the string literal is in parens:
```
> lua -e 'getmetatable("").__call = function() print"called" end; ("foo")()'
called
```