### PR TITLE
Keep parenthesis on enclosed function calls.

### DIFF
--- a/luamin.js
+++ b/luamin.js
@@ -213,6 +213,7 @@
 		var result = '';
 		var type = base.type;
 		var needsParens = base.inParens && (
+			type == 'CallExpression' ||
 			type == 'BinaryExpression' ||
 			type == 'FunctionDeclaration' ||
 			type == 'TableConstructorExpression' ||
@@ -349,8 +350,6 @@
 				}
 			});
 			result += ')';
-			if (expression.inParens)
-				result = '(' + result + ')';
 
 		} else if (expressionType == 'TableCallExpression') {
 

--- a/luamin.js
+++ b/luamin.js
@@ -349,6 +349,8 @@
 				}
 			});
 			result += ')';
+			if (expression.inParens)
+				result = '(' + result + ')';
 
 		} else if (expressionType == 'TableCallExpression') {
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -646,6 +646,11 @@
 				'minified': 'a(1,2,3)'
 			},
 			{
+				'description': 'CallStatement',
+				'original': '(select(1, ...))',
+				'minified': '(select(1,...))'
+			},
+			{
 				'description': 'CallStatement + CallExpression',
 				'original': 'a()()',
 				'minified': 'a()()'

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -646,7 +646,7 @@
 				'minified': 'a(1,2,3)'
 			},
 			{
-				'description': 'CallStatement',
+				'description': 'EnclosedCallStatement',
 				'original': '(select(1, ...))',
 				'minified': '(select(1,...))'
 			},


### PR DESCRIPTION
Closes #62

This also directly replaces [PR #52](https://github.com/mathiasbynens/luamin/pull/52/), as the effect of that issue was more generic than known at the time