### PR TITLE
Fix multiple cases of bracket and semicolon mishandling

### DIFF
--- a/luamin.js
+++ b/luamin.js
@@ -350,16 +350,25 @@
 				}
 			});
 			result += ')';
+			if (expression.inParens) {
+				result = '(' + result + ")";
+			}
 
 		} else if (expressionType == 'TableCallExpression') {
 
 			result = formatBase(expression.base) +
 				formatExpression(expression.arguments);
+			if (expression.inParens) {
+				result = '(' + result + ")";
+			}
 
 		} else if (expressionType == 'StringCallExpression') {
 
 			result = formatBase(expression.base) +
 				formatExpression(expression.argument);
+			if (expression.inParens) {
+				result = '(' + result + ")";
+			}
 
 		} else if (expressionType == 'IndexExpression') {
 

--- a/luamin.js
+++ b/luamin.js
@@ -171,6 +171,19 @@
 		if (lastCharA == '' || firstCharB == '') {
 			return a + b;
 		}
+		if (separator == ';' && firstCharB == '(') {
+			if (
+				regexAlphaNumUnderscore.test(lastCharA) || // Could be an Identifier or a NumberExpression, we don't know, best to be safe
+				lastCharA == ')' ||
+				lastCharA == '"' ||
+				lastCharA == "'" ||
+				lastCharA == '}' ||
+				lastCharA == ']'
+			) {
+				// e.g. `a=b` + `(c or d)(e)` as 2 different statements (; required)
+				return a + separator + b
+			}
+		}
 		if (regexAlphaUnderscore.test(lastCharA)) {
 			if (regexAlphaNumUnderscore.test(firstCharB)) {
 				// e.g. `while` + `1`

--- a/luamin.js
+++ b/luamin.js
@@ -213,12 +213,12 @@
 		var result = '';
 		var type = base.type;
 		var needsParens = base.inParens && (
-			type == 'CallExpression' ||
-			type == 'BinaryExpression' ||
-			type == 'FunctionDeclaration' ||
-			type == 'TableConstructorExpression' ||
-			type == 'LogicalExpression' ||
-			type == 'StringLiteral'
+			type != 'Identifier' &&
+			type != 'IndexExpression' &&
+			type != 'MemberExpression' &&
+			type != 'CallExpression' &&
+			type != 'TableCallExpression' &&
+			type != 'StringCallExpression'
 		);
 		if (needsParens) {
 			result += '(';
@@ -353,12 +353,12 @@
 
 		} else if (expressionType == 'TableCallExpression') {
 
-			result = formatExpression(expression.base) +
+			result = formatBase(expression.base) +
 				formatExpression(expression.arguments);
 
 		} else if (expressionType == 'StringCallExpression') {
 
-			result = formatExpression(expression.base) +
+			result = formatBase(expression.base) +
 				formatExpression(expression.argument);
 
 		} else if (expressionType == 'IndexExpression') {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1340,6 +1340,11 @@
 				'description': 'LocalStatement',
 				'original': 'local function a() end; local function a() end;',
 				'minified': 'local function a()end;local function a()end'
+			},
+			{
+				'description': 'LocalStatement + CallExpression',
+				'original': 'a = b[1];(c or d)(e)',
+				'minified': 'a=b[1];(c or d)(e)'
 			}
 		],
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -723,7 +723,7 @@
 			{
 				'description': 'CallStatement',
 				'original': '(1)()',
-				'minified': '1()'
+				'minified': '(1)()'
 			},
 			{
 				'description': 'CallStatement',
@@ -733,7 +733,12 @@
 			{
 				'description': 'CallStatement',
 				'original': '(true)()',
-				'minified': 'true()'
+				'minified': '(true)()'
+			},
+			{
+				'description': 'CallStatement',
+				'original': '(((nil)"")"")',
+				'minified': '(nil)""""'
 			},
 			{
 				'description': 'CallStatement + CallExpression',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -736,11 +736,6 @@
 				'minified': '(true)()'
 			},
 			{
-				'description': 'CallStatement',
-				'original': '(((nil)"")"")',
-				'minified': '(nil)""""'
-			},
-			{
 				'description': 'CallStatement + CallExpression',
 				'original': '(a)()()',
 				'minified': 'a()()'
@@ -869,6 +864,11 @@
 				'description': 'CallStatement + StringCallExpression + StringCallExpression',
 				'original': 'a"foo""bar"',
 				'minified': 'a"foo""bar"'
+			},
+			{
+				'description': 'CallStatement + StringCallExpression + StringCallExpression',
+				'original': '(nil) "" ""',
+				'minified': '(nil)""""'
 			},
 			{
 				'description': 'CallStatement + StringCallExpression + TableCallExpression',


### PR DESCRIPTION
### Fix prefix expressions not being bracketed when required
Now code like `(nil)()` or `("")""` will stop producing invalid syntax

Not sure why the test cases were configured to see `1()` or `true()` as valid, as calling a literal like this is invalid syntax

Based on ``prefixexp ::= var | functioncall | `(´ exp `)´`` (lua 5.1 docs)

Fixes #87
Fixes #48

### Fix truncation via parenthesis being removed when it shouldn't be
Fix `(f())` being shortened to `f()`, even though these aren't actually the same (In lua, if a call expression is surrounded by brackets, its result will always be truncated to one value, which can be an important difference)

Solves the first issue of #88

### Fix semicolons not being written in potential ambiguous syntax cases
Fixes the case where `a = b; ({})(c)` (and similar statement combinations) would be written without the semicolon when minified, causing it to become one large statement

The only way to start a statement with anything other than an alphanumeric (+ underscore) character is a call statement that has its base wrapped in brackets (see `stat ::=` BNF), so if we see this occur we make sure the end of our first statement couldn't be construed as a prefixexp (which I've just considered might encompass every possible ending to a statement)

Not perfect in terms of minification since it just considers what the last character is instead of its context (e.g. `do end;({})()` is the same with or without the semicolon), but we only pass the resultant string, not the statements involved, so I don't think this can be easily improved

Fully fixes #88