### PR TITLE
Improve minification by opting for shorthand call expressions where possible

### DIFF
--- a/luamin.js
+++ b/luamin.js
@@ -341,15 +341,23 @@
 
 		} else if (expressionType == 'CallExpression') {
 
-			result = formatBase(expression.base) + '(';
+			if (expression.arguments.length == 1 && (
+				expression.arguments[0].type == 'TableConstructorExpression' ||
+				expression.arguments[0].type == 'StringLiteral'
+			)) {
+				result = formatExpression(expression.base) +
+					formatExpression(expression.arguments[0]);
+			} else {
+				result = formatBase(expression.base) + '(';
 
-			each(expression.arguments, function(argument, needsComma) {
-				result += formatExpression(argument);
-				if (needsComma) {
-					result += ',';
-				}
-			});
-			result += ')';
+				each(expression.arguments, function(argument, needsComma) {
+					result += formatExpression(argument);
+					if (needsComma) {
+						result += ',';
+					}
+				});
+				result += ')';
+			}
 
 		} else if (expressionType == 'TableCallExpression') {
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -485,12 +485,12 @@
 			{
 				'description': 'MemberExpression + CallExpression on a TableConstructorExpression',
 				'original': 'x = ({ foo = print }):foo("test")',
-				'minified': 'x=({foo=print}):foo("test")'
+				'minified': 'x=({foo=print}):foo"test"'
 			},
 			{
 				'description': 'MemberExpression + CallExpression on a TableConstructorExpression',
 				'original': 'x = ({ foo = print }).foo("test")',
-				'minified': 'x=({foo=print}).foo("test")'
+				'minified': 'x=({foo=print}).foo"test"'
 			},
 			{
 				'description': 'LogicalExpression in parenthesis + MemberExpression + CallExpression',


### PR DESCRIPTION
Forces all regular CallExpressions with only 1 string or table literal argument into their respective shorthand (`f""` or `f{}`)

Done as a seperate branch/pr since its purpose is different from the other current pull request